### PR TITLE
Parse Issue: "every other monday"

### DIFF
--- a/lib/tokenizers/weekly.ex
+++ b/lib/tokenizers/weekly.ex
@@ -1,10 +1,11 @@
 defmodule Repeatex.Tokenizer.Weekly do
   use Repeatex.Helper
 
-  match_type :weekly, ~r/(each|every|bi-?|^)\s?(week|(sun|mon|tues?|wedn?e?s?|thurs?|fri|satu?r?)($|day| ))/
+  match_type :weekly, ~r/(each|every|bi-?|other|^)\s?(week|(sun|mon|tues?|wedn?e?s?|thurs?|fri|satu?r?)($|day| ))/
 
   match_freq 1, ~r/^(sun|mon|tues?|wedn?e?s?|thurs?|fri|satu?r?)d?a?y?s?$/
   match_freq 1, ~r/(each|every|of the) (week|sun|mon|tues?|wedn?e?s?|thurs?|fri|satu?r?)/
+  match_freq 2, ~r/(each|every|of the) other (week|sun|mon|tues?|wedn?e?s?|thurs?|fri|satu?r?)/
   match_freq "digit", ~r/(?<digit>\d+).(week)/
   match_freq 2, ~r/weekly/
   match_freq 2, ~r/bi-?weekly/

--- a/test/tokenizers/weekly_test.exs
+++ b/test/tokenizers/weekly_test.exs
@@ -17,6 +17,9 @@ defmodule Tokenizers.WeeklyTest do
 
   facts "tokenize" do
     it "parses single day" do
+      Weekly.tokenize("every other thursday")
+        |> equals %Repeat{days: [:thursday], type: :weekly, frequency: 2}
+
       Weekly.tokenize("every week on thursday")
         |> equals %Repeat{days: [:thursday], type: :weekly, frequency: 1}
 


### PR DESCRIPTION
The description "every other monday" was supposed to be parsed properly, but wasn't.
