### PR TITLE
Replace deprecated use of Mix.Util

### DIFF
--- a/lib/helper.ex
+++ b/lib/helper.ex
@@ -125,7 +125,7 @@ defmodule Repeatex.Helper do
   def convert_and_concat(base_module, type) when is_atom(type) do
     try do
       module = type |> to_string
-        |> Mix.Utils.camelize
+        |> Macro.camelize
         |> String.to_atom
       Module.safe_concat(base_module, module)
     rescue ArgumentError -> nil


### PR DESCRIPTION
The Macro module is the modern way to perform camelize. Mix.Utils.camelize is not available in production environments and causes an UndefinedFunction error.

Similar issue https://github.com/trenpixster/addict/pull/75